### PR TITLE
Put @tag at the bottom of Javadoc comment block

### DIFF
--- a/src/main/java/org/spdx/Configuration.java
+++ b/src/main/java/org/spdx/Configuration.java
@@ -25,13 +25,17 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * The configuration class for the Spdx-Java-Library. When a caller attempts to retrieve a configuration property, it
+ * The configuration class for the Spdx-Java-Library
+ * <p>
+ * When a caller attempts to retrieve a configuration property, it
  * will first be checked in the Java system properties (i.e. set via `-D` command line options to the JVM, or by
  * programmatic calls to `System.setProperty()` in code), and will then fall back on a properties file in the classpath.
  * That file must be called `/resources/spdx-java-library.properties`.
  * <p>
  * Please see the documentation for specifics on what configuration options Spdx-Java-Library supports, and how they
  * impact the library's behavior.
+ *
+ * @author Gary O'Neall
  */
 public final class Configuration {
     private static final Logger logger = LoggerFactory.getLogger(Configuration.class.getName());

--- a/src/main/java/org/spdx/library/LicenseInfoFactory.java
+++ b/src/main/java/org/spdx/library/LicenseInfoFactory.java
@@ -42,6 +42,7 @@ import org.spdx.utility.license.LicenseExpressionParser;
 
 /**
  * Factory for creating SPDXLicenseInfo objects from a Jena model
+ * 
  * @author Gary O'Neall
  */
 @SuppressWarnings("unused")

--- a/src/main/java/org/spdx/library/ListedLicenses.java
+++ b/src/main/java/org/spdx/library/ListedLicenses.java
@@ -48,7 +48,6 @@ import org.spdx.storage.listedlicense.SpdxV3ListedLicenseModelStore;
  * Singleton class which holds the listed licenses
  * 
  * @author Gary O'Neall
- *
  */
 @SuppressWarnings({"UnusedReturnValue", "unused"})
 public class ListedLicenses {

--- a/src/main/java/org/spdx/library/ModelCopyManager.java
+++ b/src/main/java/org/spdx/library/ModelCopyManager.java
@@ -50,7 +50,6 @@ import org.spdx.storage.PropertyDescriptor;
  * This object can be passed into the constructor for ModelObjects to allow the objects to be copied.
  * 
  * @author Gary O'Neall
- *
  */
 @SuppressWarnings("unused")
 public class ModelCopyManager implements IModelCopyManager {

--- a/src/main/java/org/spdx/library/SpdxConversionException.java
+++ b/src/main/java/org/spdx/library/SpdxConversionException.java
@@ -20,8 +20,10 @@ package org.spdx.library;
 import org.spdx.core.InvalidSPDXAnalysisException;
 
 /**
- * @author gary
- *
+ * Exception thrown when there is an error during the conversion of SPDX
+ * documents
+ * 
+ * @author Gary O'Neall
  */
 @SuppressWarnings("unused")
 public class SpdxConversionException extends InvalidSPDXAnalysisException {

--- a/src/main/java/org/spdx/library/SpdxModelFactory.java
+++ b/src/main/java/org/spdx/library/SpdxModelFactory.java
@@ -49,7 +49,6 @@ import org.spdx.storage.IModelStore;
  * The <code>inflateModelObject</code> methods will create an initial object based on the name of the type
  * 
  * @author Gary O'Neall
- *
  */
 @SuppressWarnings("unused")
 public class SpdxModelFactory {

--- a/src/main/java/org/spdx/library/conversion/ExternalMapInfo.java
+++ b/src/main/java/org/spdx/library/conversion/ExternalMapInfo.java
@@ -33,10 +33,9 @@ import org.spdx.storage.IModelStore;
 import org.spdx.storage.IModelStore.IdType;
 
 /**
- * @author Gary O'Neall
- * 
  * Information about an ExternalMap captured from an ExternalDocumentRef
  *
+ * @author Gary O'Neall
  */
 @SuppressWarnings("unused")
 public class ExternalMapInfo {

--- a/src/main/java/org/spdx/library/conversion/ISpdxConverter.java
+++ b/src/main/java/org/spdx/library/conversion/ISpdxConverter.java
@@ -18,10 +18,9 @@
 package org.spdx.library.conversion;
 
 /**
- * @author Gary O'Neall
- * 
  * Interface for classes that can convert from one SPDX spec version to another
  *
+ * @author Gary O'Neall
  */
 public interface ISpdxConverter {
 

--- a/src/main/java/org/spdx/library/conversion/Spdx2to3Converter.java
+++ b/src/main/java/org/spdx/library/conversion/Spdx2to3Converter.java
@@ -87,11 +87,10 @@ import org.spdx.storage.IModelStore.IdType;
 import org.spdx.storage.listedlicense.SpdxListedLicenseModelStore;
 
 /**
- * @author Gary O'Neall
- * <p>
  * Converts SPDX spec version 2.X objects to SPDX spec version 3.X and stores the result in the
  * toModelStore
  *
+ * @author Gary O'Neall
  */
 @SuppressWarnings({"OptionalGetWithoutIsPresent", "LoggingSimilarMessage"})
 public class Spdx2to3Converter implements ISpdxConverter {

--- a/src/main/java/org/spdx/library/conversion/package-info.java
+++ b/src/main/java/org/spdx/library/conversion/package-info.java
@@ -16,12 +16,11 @@
  *   limitations under the License.
  */
 /**
- * @author Gary O'Neall
- * 
- * This package contains classes that convert between major versions of SPDX
+ * Classes that convert between major versions of SPDX
  * 
  * These classes can be used directly (e.g. from a web application or CLI) or 
  * from the <code>CopyManager</code>.
  *
+ * @author Gary O'Neall
  */
 package org.spdx.library.conversion;

--- a/src/main/java/org/spdx/library/package-info.java
+++ b/src/main/java/org/spdx/library/package-info.java
@@ -16,8 +16,7 @@
  *   limitations under the License.
  */
 /**
- * Package containing useful library functions for reading, writing, and manipulating 
- * SPDX documents.
+ * Functions for reading, writing, and manipulating SPDX documents
  * 
  * The <code>org.spdx.library.model.compat.v2.compat.v2</code> package represents the SPDX model as Java objects
  * with getters and setters to support manipulating the SPDX documents.
@@ -30,6 +29,5 @@
  * for creating SPDX documents and license information resp.
  * 
  * @author Gary O'Neall
- *
  */
 package org.spdx.library;

--- a/src/main/java/org/spdx/storage/listedlicense/CrossRefJson.java
+++ b/src/main/java/org/spdx/storage/listedlicense/CrossRefJson.java
@@ -34,7 +34,6 @@ import org.spdx.storage.PropertyDescriptor;
  * JSON Representation of a CrossRef
  * 
  * @author Gary O'Neall
- *
  */
 @SuppressWarnings("unused")
 public class CrossRefJson {

--- a/src/main/java/org/spdx/storage/listedlicense/ExceptionJson.java
+++ b/src/main/java/org/spdx/storage/listedlicense/ExceptionJson.java
@@ -40,8 +40,7 @@ import org.spdx.storage.PropertyDescriptor;
  * <p>
  * Licenses in the JSON format can be found at spdx.org/licenses/[exceptionid].json
  * 
- * @author Gary O'Neall 
- *
+ * @author Gary O'Neall
  */
 @SuppressWarnings("unused")
 public class ExceptionJson {

--- a/src/main/java/org/spdx/storage/listedlicense/ExceptionJsonTOC.java
+++ b/src/main/java/org/spdx/storage/listedlicense/ExceptionJsonTOC.java
@@ -33,7 +33,6 @@ import org.spdx.library.model.v2.license.ListedLicenseException;
  * at spdx.org/licenses/licenses.json
  * 
  * @author Gary O'Neall
- *
  */
 public class ExceptionJsonTOC {
 	public static class ExceptionJson {

--- a/src/main/java/org/spdx/storage/listedlicense/IListedLicenseStore.java
+++ b/src/main/java/org/spdx/storage/listedlicense/IListedLicenseStore.java
@@ -25,10 +25,9 @@ import org.spdx.library.model.v3_0_1.core.CreationInfo;
 import org.spdx.storage.IModelStore;
 
 /**
- * @author Gary O'Neall
- * 
  * Extends the model store to include interfaces specific to listed licenses
  *
+ * @author Gary O'Neall
  */
 public interface IListedLicenseStore extends IModelStore {
 

--- a/src/main/java/org/spdx/storage/listedlicense/LicenseCreationInfo.java
+++ b/src/main/java/org/spdx/storage/listedlicense/LicenseCreationInfo.java
@@ -36,10 +36,9 @@ import org.spdx.library.model.v3_0_1.core.Agent;
 import org.spdx.storage.PropertyDescriptor;
 
 /**
- * @author Gary O'Neall
- * 
  * Creation information for the listed license store
  *
+ * @author Gary O'Neall
  */
 public class LicenseCreationInfo {
 

--- a/src/main/java/org/spdx/storage/listedlicense/LicenseCreatorAgent.java
+++ b/src/main/java/org/spdx/storage/listedlicense/LicenseCreatorAgent.java
@@ -33,10 +33,9 @@ import org.spdx.library.model.v3_0_1.core.CreationInfo;
 import org.spdx.storage.PropertyDescriptor;
 
 /**
- * @author Gary O'Neall
- * 
  * Storage for the creator agent of the license list
  *
+ * @author Gary O'Neall
  */
 @SuppressWarnings("unused")
 public class LicenseCreatorAgent {

--- a/src/main/java/org/spdx/storage/listedlicense/LicenseJson.java
+++ b/src/main/java/org/spdx/storage/listedlicense/LicenseJson.java
@@ -41,8 +41,7 @@ import org.spdx.storage.PropertyDescriptor;
  * <p>
  * Licenses in the JSON format can be found at spdx.org/licenses/[licenseid].json
  * 
- * @author Gary O'Neall 
- *
+ * @author Gary O'Neall
  */
 @SuppressWarnings("unused")
 public class LicenseJson {

--- a/src/main/java/org/spdx/storage/listedlicense/LicenseJsonTOC.java
+++ b/src/main/java/org/spdx/storage/listedlicense/LicenseJsonTOC.java
@@ -33,7 +33,6 @@ import org.spdx.library.model.v2.license.SpdxListedLicense;
  * at spdx.org/licenses/licenses.json
  * 
  * @author Gary O'Neall
- *
  */
 public class LicenseJsonTOC {
 	

--- a/src/main/java/org/spdx/storage/listedlicense/SpdxListedLicenseLocalStore.java
+++ b/src/main/java/org/spdx/storage/listedlicense/SpdxListedLicenseLocalStore.java
@@ -24,11 +24,10 @@ import org.spdx.core.InvalidSPDXAnalysisException;
 
 
 /**
- * @author Gary O'Neall
- * 
  * Model store for listed licenses using the JSON files in the resources/stdlicenses directory.
  * Note the resources/stdlicenses must be on the build path.
  *
+ * @author Gary O'Neall
  */
 public class SpdxListedLicenseLocalStore extends SpdxListedLicenseModelStore {
 	

--- a/src/main/java/org/spdx/storage/listedlicense/SpdxListedLicenseModelStore.java
+++ b/src/main/java/org/spdx/storage/listedlicense/SpdxListedLicenseModelStore.java
@@ -65,7 +65,6 @@ import com.google.gson.Gson;
  * CrossRef information is stored within the LicenseJson file.  Id's are anonymous and generated. 
  * 
  * @author Gary O'Neall
- *
  */
 @SuppressWarnings("LoggingSimilarMessage")
 public abstract class SpdxListedLicenseModelStore implements IListedLicenseStore {

--- a/src/main/java/org/spdx/storage/listedlicense/SpdxListedLicenseWebStore.java
+++ b/src/main/java/org/spdx/storage/listedlicense/SpdxListedLicenseWebStore.java
@@ -26,9 +26,8 @@ import org.spdx.library.model.v2.SpdxConstantsCompatV2;
 import org.spdx.utility.DownloadCache;
 
 /**
- * @author gary   Original code
- * @author pmonks Optional caching of downloaded files
- *
+ * @author Gary O'Neall   Original code
+ * @author Peter Monks    Optional caching of downloaded files
  */
 public class SpdxListedLicenseWebStore extends SpdxListedLicenseModelStore {
 

--- a/src/main/java/org/spdx/storage/listedlicense/SpdxV2ListedLicenseModelStore.java
+++ b/src/main/java/org/spdx/storage/listedlicense/SpdxV2ListedLicenseModelStore.java
@@ -35,10 +35,9 @@ import org.spdx.storage.IModelStore;
 import org.spdx.storage.PropertyDescriptor;
 
 /**
- * @author Gary O'Neall
- * 
  * Model store for generating SPDX version 2.X listed license and listed exceptions
  *
+ * @author Gary O'Neall
  */
 public class SpdxV2ListedLicenseModelStore implements IModelStore {
 	

--- a/src/main/java/org/spdx/storage/listedlicense/SpdxV3ListedLicenseModelStore.java
+++ b/src/main/java/org/spdx/storage/listedlicense/SpdxV3ListedLicenseModelStore.java
@@ -34,8 +34,9 @@ import org.spdx.storage.IModelStore;
 import org.spdx.storage.PropertyDescriptor;
 
 /**
- * @author gary
+ * Model store for generating SPDX version 3.X listed license and listed exceptions
  *
+ * @author Gary O'Neall
  */
 public class SpdxV3ListedLicenseModelStore implements IModelStore {
 	

--- a/src/main/java/org/spdx/storage/listedlicense/package-info.java
+++ b/src/main/java/org/spdx/storage/listedlicense/package-info.java
@@ -16,13 +16,12 @@
  *   limitations under the License.
  */
 /**
- * @author Gary O'Neall
- * <p>
  * Storage for SPDX listed licenses.
  * <p>
  * The <code>SpdxListedLicenseModelStore</code> is the default storage which pull the data from JSON files at spdx.org/licenses
  * 
  * The <code>SpdxListedLicenseLocalModelStore</code> uses a local copy of the licenses stored in the resources/licenses directory
- *
+ * 
+ * @author Gary O'Neall
  */
 package org.spdx.storage.listedlicense;

--- a/src/main/java/org/spdx/storage/simple/ExtendedSpdxStore.java
+++ b/src/main/java/org/spdx/storage/simple/ExtendedSpdxStore.java
@@ -36,7 +36,6 @@ import org.spdx.storage.PropertyDescriptor;
  * with a choice of underlying message stores.
  * 
  * @author Gary O'Neall
- *
  */
 @SuppressWarnings("unused")
 public abstract class ExtendedSpdxStore implements IModelStore {

--- a/src/main/java/org/spdx/storage/simple/InMemSpdxStore.java
+++ b/src/main/java/org/spdx/storage/simple/InMemSpdxStore.java
@@ -47,15 +47,14 @@ import org.spdx.storage.IModelStore;
 import org.spdx.storage.PropertyDescriptor;
 
 /**
- * @author Gary O'Neall
- * <p>
- * In memory implementation of an SPDX store.
+ * In memory implementation of an SPDX store
  * <p>
  * This implementation primarily uses <code>ConcurrentHashMaps</code>.
  * <p>
  * It is designed to be thread-safe and low CPU utilization.  It may use significant amounts of memory
  * for larger SPDX documents.
  *
+ * @author Gary O'Neall
  */
 public class InMemSpdxStore implements IModelStore {
 

--- a/src/main/java/org/spdx/storage/simple/StoredTypedItem.java
+++ b/src/main/java/org/spdx/storage/simple/StoredTypedItem.java
@@ -28,7 +28,6 @@ import org.spdx.storage.PropertyDescriptor;
  * Individual item to be stored in memory
  * 
  * @author Gary O'Neall
- *
  */
 @SuppressWarnings({"UnusedReturnValue", "unused"})
 public class StoredTypedItem extends TypedValue {

--- a/src/main/java/org/spdx/storage/simple/package-info.java
+++ b/src/main/java/org/spdx/storage/simple/package-info.java
@@ -16,9 +16,8 @@
  *   limitations under the License.
  */
 /**
- * @author Gary O'Neall
- * 
  * Simple SPDX storage using in memory basic functions
  *
+ * @author Gary O'Neall
  */
 package org.spdx.storage.simple;

--- a/src/main/java/org/spdx/utility/DownloadCache.java
+++ b/src/main/java/org/spdx/utility/DownloadCache.java
@@ -53,6 +53,8 @@ import org.slf4j.LoggerFactory;
 import org.spdx.Configuration;
 
 /**
+ * Flexible download cache for the rest of the library
+ * <p>
  * This singleton class provides a flexible download cache for the rest of the library.  If enabled, URLs that are
  * requested using this class will have their content automatically cached locally on disk (in a directory that adheres
  * to the XDG Base Directory Specification - <a href="https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html">...</a>),
@@ -67,6 +69,8 @@ import org.spdx.Configuration;
  * * org.spdx.storage.listedlicense.cacheCheckIntervalSecs:
  *   How many seconds should the cache wait between issuing ETag requests to determine whether cached content is
  *   stale? Defaults to 86,400 seconds (24 hours).
+ * 
+ * @author Gary O'Neall
  */
 public final class DownloadCache {
     private static final Logger logger = LoggerFactory.getLogger(DownloadCache.class);

--- a/src/main/java/org/spdx/utility/compare/CompareTemplateOutputHandler.java
+++ b/src/main/java/org/spdx/utility/compare/CompareTemplateOutputHandler.java
@@ -37,8 +37,8 @@ import org.spdx.licenseTemplate.LineColumn;
 /**
  * Compares the output of a parsed license template to text.  The method matches is called after
  * the document is parsed to determine if the text matches.
+ * 
  * @author Gary O'Neall
- *
  */
 public class CompareTemplateOutputHandler implements
 		ILicenseTemplateOutputHandler {

--- a/src/main/java/org/spdx/utility/compare/FilterTemplateOutputHandler.java
+++ b/src/main/java/org/spdx/utility/compare/FilterTemplateOutputHandler.java
@@ -27,11 +27,10 @@ import org.spdx.licenseTemplate.LicenseTemplateRule;
 import org.spdx.licenseTemplate.LicenseTextHelper;
 
 /**
- * @deprecated The <code>TemplateRegexMatcher</code> class should be used in place of this class.  This class will be removed in the next major release.
- * 
  * Filter the template output to create a list of strings filtering out optional and/or var text
+ * 
+ * @deprecated The <code>TemplateRegexMatcher</code> class should be used in place of this class.  This class will be removed in the next major release.
  * @author Gary O'Neall
- *
  */
 @Deprecated
 public class FilterTemplateOutputHandler implements ILicenseTemplateOutputHandler {

--- a/src/main/java/org/spdx/utility/compare/LicenseCompareHelper.java
+++ b/src/main/java/org/spdx/utility/compare/LicenseCompareHelper.java
@@ -51,8 +51,8 @@ import org.spdx.utility.compare.FilterTemplateOutputHandler.VarTextHandling;
 
 /**
  * Primarily a static class of helper functions for comparing two SPDX licenses
+ * 
  * @author Gary O'Neall
- *
  */
 @SuppressWarnings("deprecation")
 public class LicenseCompareHelper {

--- a/src/main/java/org/spdx/utility/compare/SpdxCompareException.java
+++ b/src/main/java/org/spdx/utility/compare/SpdxCompareException.java
@@ -1,8 +1,10 @@
 package org.spdx.utility.compare;
 
 /**
+ * Exception thrown when there is an error during the comparison of SPDX
+ * documents
+ * 
  * @author Gary O'Neall
- *
  */
 public class SpdxCompareException extends Exception {
 

--- a/src/main/java/org/spdx/utility/compare/SpdxComparer.java
+++ b/src/main/java/org/spdx/utility/compare/SpdxComparer.java
@@ -53,6 +53,7 @@ import org.spdx.library.model.v2.license.ExtractedLicenseInfo;
 import org.spdx.licenseTemplate.LicenseTextHelper;
 /**
  * Performs a comparison between two or more SPDX documents and holds the results of the comparison
+ * <p>
  * The main function to perform the comparison is <code>compare(spdxdoc1, spdxdoc2)</code>
  * <p>
  * For files, the comparison results are separated into unique files based on the file names
@@ -66,7 +67,6 @@ import org.spdx.licenseTemplate.LicenseTextHelper;
  * getters where the compare operation is started in the middle of a get operation.
  * 
  * @author Gary O'Neall
- *
  */
 @SuppressWarnings("BooleanMethodIsAlwaysInverted")
 public class SpdxComparer {

--- a/src/main/java/org/spdx/utility/compare/SpdxExternalRefDifference.java
+++ b/src/main/java/org/spdx/utility/compare/SpdxExternalRefDifference.java
@@ -30,7 +30,6 @@ import org.spdx.library.model.v2.enumerations.ReferenceCategory;
  * Contains information on differences between two different External Refs.
  * 
  * @author Gary O'Neall
- *
  */
 public class SpdxExternalRefDifference {
 	

--- a/src/main/java/org/spdx/utility/compare/SpdxFileComparer.java
+++ b/src/main/java/org/spdx/utility/compare/SpdxFileComparer.java
@@ -35,11 +35,13 @@ import org.spdx.library.model.v2.SpdxItem;
 import org.spdx.library.model.v2.license.AnyLicenseInfo;
 
 /**
- * Compares two SPDX files.  The <code>compare(fileA, fileB)</code> method will perform the comparison and
+ * Compares two SPDX files
+ * <p>
+ * The <code>compare(fileA, fileB)</code> method will perform the comparison and
  * store the results.  <code>isDifferenceFound()</code> will return true of any 
  * differences were found.
+ * 
  * @author Gary O'Neall
- *
  */
 public class SpdxFileComparer extends SpdxItemComparer {
 	private boolean inProgress = false;

--- a/src/main/java/org/spdx/utility/compare/SpdxFileDifference.java
+++ b/src/main/java/org/spdx/utility/compare/SpdxFileDifference.java
@@ -34,8 +34,8 @@ import org.spdx.library.model.v2.license.AnyLicenseInfo;
 
 /**
  * Contains the results of a comparison between two SPDX files with the same name
+ * 
  * @author Gary O'Neall
- *
  */
 public class SpdxFileDifference extends SpdxItemDifference {
 

--- a/src/main/java/org/spdx/utility/compare/SpdxItemComparer.java
+++ b/src/main/java/org/spdx/utility/compare/SpdxItemComparer.java
@@ -35,11 +35,13 @@ import org.spdx.library.model.v2.license.AnyLicenseInfo;
 
 
 /**
- * Compares two SPDX items.  The <code>compare(itemA, itemB)</code> method will perform the comparison and
+ * Compares two SPDX items
+ * <p>
+ * The <code>compare(itemA, itemB)</code> method will perform the comparison and
  * store the results.  <code>isDifferenceFound()</code> will return true of any 
  * differences were found.
- * @author Gary
  *
+ * @author Gary O'Neall
  */
 public class SpdxItemComparer {
 	private boolean itemInProgress = false;

--- a/src/main/java/org/spdx/utility/compare/SpdxItemDifference.java
+++ b/src/main/java/org/spdx/utility/compare/SpdxItemDifference.java
@@ -27,9 +27,9 @@ import org.spdx.library.model.v2.SpdxItem;
 import org.spdx.library.model.v2.license.AnyLicenseInfo;
 
 /**
- *  Contains the results of a comparison between two SPDX items with the same name
+ * Contains the results of a comparison between two SPDX items with the same name
+ * 
  * @author Gary O'Neall
- *
  */
 public class SpdxItemDifference {
 	

--- a/src/main/java/org/spdx/utility/compare/SpdxLicenseDifference.java
+++ b/src/main/java/org/spdx/utility/compare/SpdxLicenseDifference.java
@@ -24,10 +24,12 @@ import org.spdx.library.model.v2.license.ExtractedLicenseInfo;
 
 /**
  * Contains the results of a comparison between two SPDX non-standard licenses
+ * <p>
+ * Contains the results of a comparison between two SPDX non-standard licenses,
  * where the license text is equivalent and the license comment, license ID, or
- * other fields are different
+ * other fields are different.
+ * 
  * @author Gary O'Neall
- *
  */
 public class SpdxLicenseDifference {
 

--- a/src/main/java/org/spdx/utility/compare/SpdxPackageComparer.java
+++ b/src/main/java/org/spdx/utility/compare/SpdxPackageComparer.java
@@ -38,11 +38,13 @@ import org.spdx.library.model.v2.SpdxItem;
 import org.spdx.library.model.v2.SpdxPackage;
 
 /**
- * Compares two SPDX package.  The <code>compare(pkgA, pkgB)</code> method will perform the comparison and
+ * Compares two SPDX package.
+ * <p>
+ * The <code>compare(pkgA, pkgB)</code> method will perform the comparison and
  * store the results.  <code>isDifferenceFound()</code> will return true of any 
  * differences were found.
+ * 
  * @author Gary O'Neall
- *
  */
 public class SpdxPackageComparer extends SpdxItemComparer {
 	private boolean inProgress = false;

--- a/src/main/java/org/spdx/utility/compare/SpdxSnippetComparer.java
+++ b/src/main/java/org/spdx/utility/compare/SpdxSnippetComparer.java
@@ -32,11 +32,13 @@ import org.spdx.library.model.v2.SpdxSnippet;
 import org.spdx.library.model.v2.pointer.StartEndPointer;
 
 /**
- * Compares two SPDX snippets.  The <code>compare(snippetA, snippetB)</code> method will perform the comparison and
+ * Compares two SPDX snippets
+ * <p>
+ * The <code>compare(snippetA, snippetB)</code> method will perform the comparison and
  * store the results.  <code>isDifferenceFound()</code> will return true of any 
  * differences were found.
+ * 
  * @author Gary O'Neall
- *
  */
 public class SpdxSnippetComparer extends SpdxItemComparer {
 

--- a/src/main/java/org/spdx/utility/compare/TemplateRegexMatcher.java
+++ b/src/main/java/org/spdx/utility/compare/TemplateRegexMatcher.java
@@ -49,7 +49,6 @@ import org.spdx.licenseTemplate.SpdxLicenseTemplateHelper;
  * and <code>getEndRegex(int wordLimit)</code> will return a regular expression to match the end of a license
  * 
  * @author Gary O'Neall
- *
  */
 public class TemplateRegexMatcher implements ILicenseTemplateOutputHandler {
 	

--- a/src/main/java/org/spdx/utility/compare/package-info.java
+++ b/src/main/java/org/spdx/utility/compare/package-info.java
@@ -19,6 +19,5 @@
  * Utility classes for comparing SPDX model objects
  * 
  * @author Gary O'Neall
- *
  */
 package org.spdx.utility.compare;

--- a/src/main/java/org/spdx/utility/license/LicenseExpressionParser.java
+++ b/src/main/java/org/spdx/utility/license/LicenseExpressionParser.java
@@ -65,12 +65,12 @@ import org.spdx.storage.IModelStore;
 import org.spdx.storage.IModelStore.IdType;
 
 /**
- * A parser for the SPDX License Expressions as documented in the SPDX appendix.
+ * A parser for the SPDX License Expressions as documented in the SPDX appendix
  * <p>
  * This is a static help class.  The primary method is parseLicenseExpression which 
  * returns an AnyLicenseInfo.
+ * 
  * @author Gary O'Neall
- *
  */
 public class LicenseExpressionParser {
 

--- a/src/main/java/org/spdx/utility/license/LicenseParserException.java
+++ b/src/main/java/org/spdx/utility/license/LicenseParserException.java
@@ -2,11 +2,14 @@ package org.spdx.utility.license;
 
 import org.spdx.core.InvalidSPDXAnalysisException;
 
+/**
+ * Exception thrown when there is an error during the parsing of SPDX license
+ * information
+ * 
+ * @author Gary O'Neall
+ */
 public class LicenseParserException extends InvalidSPDXAnalysisException {
-	
-	/**
-	 * 
-	 */
+
 	private static final long serialVersionUID = 1L;
 
 	/**

--- a/src/main/java/org/spdx/utility/license/package-info.java
+++ b/src/main/java/org/spdx/utility/license/package-info.java
@@ -16,9 +16,8 @@
  *   limitations under the License.
  */
 /**
- * @author Gary O'Neall
- * 
  * Utilities to help with license expression parsing and creation
  *
+ * @author Gary O'Neall
  */
 package org.spdx.utility.license;

--- a/src/main/java/org/spdx/utility/package-info.java
+++ b/src/main/java/org/spdx/utility/package-info.java
@@ -19,6 +19,5 @@
  * Utility classes that may be of use for libraries or programs that use the SPDX library
  * 
  * @author Gary O'Neall
- *
  */
 package org.spdx.utility;

--- a/src/main/java/org/spdx/utility/verificationcode/IFileChecksumGenerator.java
+++ b/src/main/java/org/spdx/utility/verificationcode/IFileChecksumGenerator.java
@@ -21,8 +21,8 @@ import java.io.IOException;
 
 /**
  * Interface for implementations of generators of file checksums
- * @author Gary O'Neall
  *
+ * @author Gary O'Neall
  */
 public interface IFileChecksumGenerator {
 	/**

--- a/src/main/java/org/spdx/utility/verificationcode/JavaSha1ChecksumGenerator.java
+++ b/src/main/java/org/spdx/utility/verificationcode/JavaSha1ChecksumGenerator.java
@@ -24,8 +24,8 @@ import java.security.NoSuchAlgorithmException;
 
 /**
  * Java sha1 checksum generator using MessageDigest
- * @author Gary O'Neall
  *
+ * @author Gary O'Neall
  */
 public class JavaSha1ChecksumGenerator implements IFileChecksumGenerator {
 	static final String SHA1_ALGORITHM = "SHA-1";

--- a/src/main/java/org/spdx/utility/verificationcode/VerificationCodeGenerator.java
+++ b/src/main/java/org/spdx/utility/verificationcode/VerificationCodeGenerator.java
@@ -45,7 +45,6 @@ import org.spdx.storage.IModelStore.IdType;
  * a file level.
  *
  * @author Gary O'Neall
- *
  */
 public class VerificationCodeGenerator {
 

--- a/src/main/java/org/spdx/utility/verificationcode/package-info.java
+++ b/src/main/java/org/spdx/utility/verificationcode/package-info.java
@@ -16,9 +16,8 @@
  *   limitations under the License.
  */
 /**
- * @author Gary O'Neall
- * 
  * Classes used to generate PackageVerificationCodes
  *
+ * @author Gary O'Neall
  */
 package org.spdx.utility.verificationcode;

--- a/src/test/java/org/spdx/library/LicenseInfoFactoryTest.java
+++ b/src/test/java/org/spdx/library/LicenseInfoFactoryTest.java
@@ -39,8 +39,7 @@ import org.spdx.storage.simple.InMemSpdxStore;
 import junit.framework.TestCase;
 
 /**
- * @author gary
- *
+ * @author Gary O'Neall
  */
 public class LicenseInfoFactoryTest extends TestCase {
 	

--- a/src/test/java/org/spdx/library/LicenseInfoFactoryTestV2.java
+++ b/src/test/java/org/spdx/library/LicenseInfoFactoryTestV2.java
@@ -39,8 +39,7 @@ import org.spdx.storage.simple.InMemSpdxStore;
 import junit.framework.TestCase;
 
 /**
- * @author gary
- *
+ * @author Gary O'Neall
  */
 public class LicenseInfoFactoryTestV2 extends TestCase {
 	

--- a/src/test/java/org/spdx/library/ModelCopyManagerTest.java
+++ b/src/test/java/org/spdx/library/ModelCopyManagerTest.java
@@ -44,7 +44,6 @@ import org.spdx.storage.simple.InMemSpdxStore;
 
 /**
  * @author Gary O'Neall
- *
  */
 public class ModelCopyManagerTest {
 	

--- a/src/test/java/org/spdx/library/ModelCopyManagerTestV2.java
+++ b/src/test/java/org/spdx/library/ModelCopyManagerTestV2.java
@@ -46,7 +46,6 @@ import org.spdx.storage.simple.InMemSpdxStore;
 
 /**
  * @author Gary O'Neall
- *
  */
 public class ModelCopyManagerTestV2 {
 	private static final String ORIGINAL_NAMESPACE = "http://something#";

--- a/src/test/java/org/spdx/library/ModelSpecConverterTest.java
+++ b/src/test/java/org/spdx/library/ModelSpecConverterTest.java
@@ -28,8 +28,7 @@ import org.junit.Test;
 import org.spdx.library.model.v2.SpdxConstantsCompatV2;
 
 /**
- * @author gary
- *
+ * @author Gary O'Neall
  */
 public class ModelSpecConverterTest {
 

--- a/src/test/java/org/spdx/library/conversion/ExternalMapInfoTest.java
+++ b/src/test/java/org/spdx/library/conversion/ExternalMapInfoTest.java
@@ -37,8 +37,7 @@ import org.spdx.storage.IModelStore.IdType;
 import org.spdx.storage.simple.InMemSpdxStore;
 
 /**
- * @author gary
- *
+ * @author Gary O'Neall
  */
 public class ExternalMapInfoTest {
 	

--- a/src/test/java/org/spdx/library/conversion/Spdx2to3ConverterTest.java
+++ b/src/test/java/org/spdx/library/conversion/Spdx2to3ConverterTest.java
@@ -91,7 +91,6 @@ import org.spdx.storage.simple.InMemSpdxStore;
 
 /**
  * @author Gary O'Neall
- *
  */
 public class Spdx2to3ConverterTest {
 	

--- a/src/test/java/org/spdx/storage/listedlicense/ExceptionJsonTOCTest.java
+++ b/src/test/java/org/spdx/storage/listedlicense/ExceptionJsonTOCTest.java
@@ -30,8 +30,7 @@ import org.spdx.utility.compare.UnitTestHelper;
 import junit.framework.TestCase;
 
 /**
- * @author gary
- *
+ * @author Gary O'Neall
  */
 public class ExceptionJsonTOCTest extends TestCase {
 

--- a/src/test/java/org/spdx/storage/listedlicense/ExceptionJsonTest.java
+++ b/src/test/java/org/spdx/storage/listedlicense/ExceptionJsonTest.java
@@ -40,8 +40,7 @@ import com.google.gson.Gson;
 import junit.framework.TestCase;
 
 /**
- * @author gary
- *
+ * @author Gary O'Neall
  */
 public class ExceptionJsonTest extends TestCase {
 

--- a/src/test/java/org/spdx/storage/listedlicense/LicenseCreationInfoTest.java
+++ b/src/test/java/org/spdx/storage/listedlicense/LicenseCreationInfoTest.java
@@ -35,8 +35,7 @@ import org.spdx.library.model.v3_0_1.SpdxConstantsV3;
 import org.spdx.library.model.v3_0_1.core.Agent;
 
 /**
- * @author gary
- *
+ * @author Gary O'Neall
  */
 public class LicenseCreationInfoTest {
 	

--- a/src/test/java/org/spdx/storage/listedlicense/LicenseCreatorAgentTest.java
+++ b/src/test/java/org/spdx/storage/listedlicense/LicenseCreatorAgentTest.java
@@ -34,8 +34,7 @@ import org.spdx.library.model.v3_0_1.SpdxConstantsV3;
 import org.spdx.library.model.v3_0_1.core.CreationInfo;
 
 /**
- * @author gary
- *
+ * @author Gary O'Neall
  */
 public class LicenseCreatorAgentTest {
 	

--- a/src/test/java/org/spdx/storage/listedlicense/LicenseJsonTOCTest.java
+++ b/src/test/java/org/spdx/storage/listedlicense/LicenseJsonTOCTest.java
@@ -32,7 +32,6 @@ import junit.framework.TestCase;
 
 /**
  * @author Gary O'Neall
- *
  */
 public class LicenseJsonTOCTest extends TestCase {
 

--- a/src/test/java/org/spdx/storage/listedlicense/LicenseJsonTest.java
+++ b/src/test/java/org/spdx/storage/listedlicense/LicenseJsonTest.java
@@ -42,8 +42,7 @@ import com.google.gson.Gson;
 import junit.framework.TestCase;
 
 /**
- * @author gary
- *
+ * @author Gary O'Neall
  */
 public class LicenseJsonTest extends TestCase {
 	

--- a/src/test/java/org/spdx/storage/listedlicense/SpdxListedLicenseLocalStoreTest.java
+++ b/src/test/java/org/spdx/storage/listedlicense/SpdxListedLicenseLocalStoreTest.java
@@ -44,8 +44,7 @@ import org.spdx.utility.compare.UnitTestHelper;
 import junit.framework.TestCase;
 
 /**
- * @author gary
- *
+ * @author Gary O'Neall
  */
 public class SpdxListedLicenseLocalStoreTest extends TestCase {
 

--- a/src/test/java/org/spdx/storage/listedlicense/SpdxListedLicenseWebStoreTest.java
+++ b/src/test/java/org/spdx/storage/listedlicense/SpdxListedLicenseWebStoreTest.java
@@ -44,8 +44,7 @@ import org.spdx.utility.compare.UnitTestHelper;
 import junit.framework.TestCase;
 
 /**
- * @author gary
- *
+ * @author Gary O'Neall
  */
 public class SpdxListedLicenseWebStoreTest extends TestCase {
 

--- a/src/test/java/org/spdx/storage/simple/InMemSpdxStoreTest.java
+++ b/src/test/java/org/spdx/storage/simple/InMemSpdxStoreTest.java
@@ -45,7 +45,6 @@ import net.jodah.concurrentunit.Waiter;
 
 /**
  * @author Gary O'Neall
- *
  */
 public class InMemSpdxStoreTest extends TestCase {
 	

--- a/src/test/java/org/spdx/storage/simple/StoredTypedItemTest.java
+++ b/src/test/java/org/spdx/storage/simple/StoredTypedItemTest.java
@@ -30,8 +30,7 @@ import org.spdx.storage.PropertyDescriptor;
 import junit.framework.TestCase;
 
 /**
- * @author gary
- *
+ * @author Gary O'Neall
  */
 public class StoredTypedItemTest extends TestCase {
 

--- a/src/test/java/org/spdx/utility/compare/FilterTemplateOutputHandlerTest.java
+++ b/src/test/java/org/spdx/utility/compare/FilterTemplateOutputHandlerTest.java
@@ -34,7 +34,6 @@ import org.spdx.utility.compare.FilterTemplateOutputHandler.VarTextHandling;
 
 /**
  * @author Gary O'Neall
- *
  */
 public class FilterTemplateOutputHandlerTest {
 	

--- a/src/test/java/org/spdx/utility/compare/LicenseCompareHelperTest.java
+++ b/src/test/java/org/spdx/utility/compare/LicenseCompareHelperTest.java
@@ -56,7 +56,6 @@ import junit.framework.TestCase;
 
 /**
  * @author Gary O'Neall
- *
  */
 @SuppressWarnings("deprecation")
 public class LicenseCompareHelperTest extends TestCase {

--- a/src/test/java/org/spdx/utility/compare/LicenseCompareHelperTestV2.java
+++ b/src/test/java/org/spdx/utility/compare/LicenseCompareHelperTestV2.java
@@ -53,7 +53,6 @@ import junit.framework.TestCase;
 
 /**
  * @author Gary O'Neall
- *
  */
 @SuppressWarnings("deprecation")
 public class LicenseCompareHelperTestV2 extends TestCase {

--- a/src/test/java/org/spdx/utility/compare/SpdxComparerTest.java
+++ b/src/test/java/org/spdx/utility/compare/SpdxComparerTest.java
@@ -77,7 +77,6 @@ import junit.framework.TestCase;
 
 /**
  * @author Gary O'Neall
- *
  */
 public class SpdxComparerTest extends TestCase {
 	

--- a/src/test/java/org/spdx/utility/compare/SpdxFileComparerTest.java
+++ b/src/test/java/org/spdx/utility/compare/SpdxFileComparerTest.java
@@ -47,7 +47,6 @@ import junit.framework.TestCase;
 
 /**
  * @author Gary O'Neall
- *
  */
 public class SpdxFileComparerTest extends TestCase {
 

--- a/src/test/java/org/spdx/utility/compare/SpdxItemComparerTest.java
+++ b/src/test/java/org/spdx/utility/compare/SpdxItemComparerTest.java
@@ -43,8 +43,7 @@ import org.spdx.storage.simple.InMemSpdxStore;
 import junit.framework.TestCase;
 
 /**
- * @author gary
- *
+ * @author Gary O'Neall
  */
 public class SpdxItemComparerTest extends TestCase {
 	

--- a/src/test/java/org/spdx/utility/compare/SpdxPackageComparerTest.java
+++ b/src/test/java/org/spdx/utility/compare/SpdxPackageComparerTest.java
@@ -54,7 +54,6 @@ import junit.framework.TestCase;
 
 /**
  * @author Gary O'Neall
- *
  */
 public class SpdxPackageComparerTest extends TestCase {
 	

--- a/src/test/java/org/spdx/utility/compare/SpdxSnippetComparerTest.java
+++ b/src/test/java/org/spdx/utility/compare/SpdxSnippetComparerTest.java
@@ -46,7 +46,6 @@ import junit.framework.TestCase;
 
 /**
  * @author Gary O'Neall
- *
  */
 public class SpdxSnippetComparerTest extends TestCase {
 	

--- a/src/test/java/org/spdx/utility/compare/TestCompareTemplateOutputHandler.java
+++ b/src/test/java/org/spdx/utility/compare/TestCompareTemplateOutputHandler.java
@@ -34,7 +34,6 @@ import org.spdx.licenseTemplate.LicenseTemplateRule.RuleType;
 
 /**
  * @author Source Auditor
- *
  */
 public class TestCompareTemplateOutputHandler {
 

--- a/src/test/java/org/spdx/utility/compare/UnitTestHelper.java
+++ b/src/test/java/org/spdx/utility/compare/UnitTestHelper.java
@@ -37,8 +37,8 @@ import org.spdx.storage.compatv2.CompatibleModelStoreWrapper;
 
 /**
  * Helper class for unit tests
- * @author Gary
  *
+ * @author Gary O'Neall
  */
 public class UnitTestHelper {
 	


### PR DESCRIPTION
To fix the issues that some of the Javadoc information do not show in the API documentation website